### PR TITLE
feat: Add kpxc_args config option to handle keyfile

### DIFF
--- a/README.org
+++ b/README.org
@@ -21,6 +21,7 @@ set kpxc_database_path $::env(HOME)/Passwords.kdbx
 set kpxc_dmenu {rofi -dmenu -no-custom -i}
 set kpxc_pinentry /usr/bin/pinentry-qt
 # set kpxc_timeout 60
+# set kpxc_args -k /path/to/keyfile
 #+end_src
 
 This is primarily meant to be invoked by pressing hotkey (either configured in the DE, or in a hotkey daemon such as [[https://github.com/baskerville/sxhkd][sxhkd]]). An example for sxhkd may look:

--- a/keepassxc-dmenu
+++ b/keepassxc-dmenu
@@ -68,7 +68,7 @@ proc pinentry_get {} {
 }
 
 proc enter_pw {kpxc_pw} {
-    spawn keepassxc-cli open "$::kpxc_database_path"
+    spawn keepassxc-cli open "$::kpxc_database_path" {*}$::kpxc_args
     expect "Enter password"
     set spawn_id $expect_out(spawn_id)
 


### PR DESCRIPTION
Adds a kpxc_args option to add extra args to the `keepassxc-cli open` command, to handle keyfiles and such.